### PR TITLE
chore(deps): lower minimum dependency versions for better compatibility

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/astral-sh/uv:python3.13-bookworm-slim
+FROM ghcr.io/astral-sh/uv:python3.10-bookworm-slim
 
 # Set the working directory
 WORKDIR /app

--- a/Dockerfile.streamable-http
+++ b/Dockerfile.streamable-http
@@ -1,4 +1,4 @@
-FROM ghcr.io/astral-sh/uv:python3.13-bookworm-slim
+FROM ghcr.io/astral-sh/uv:python3.10-bookworm-slim
 
 # Set the working directory
 WORKDIR /app

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,6 @@ readme = "README.md"
 requires-python = ">=3.10"
 dependencies = [
   "mcp[cli]>=1.12.0",
-  # "argparse>=1.4.0",
   "httpx>=0.23.1",
   "python-dotenv>=1.1.1",
   "python-dateutil>=2.8.2",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "mcp_weather_server"
-version = "0.5.0"
+version = "0.6.0"
 authors = [
   { name = "danielshih", email = "dog830228@gmail.com" },
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,15 +10,15 @@ authors = [
 ]
 description = "An MCP server for weather information"
 readme = "README.md"
-requires-python = ">=3.13"
+requires-python = ">=3.10"
 dependencies = [
-  "mcp[cli]>=1.18.0",
-  "argparse>=1.4.0",
-  "httpx>=0.28.1",
+  "mcp[cli]>=1.12.0",
+  # "argparse>=1.4.0",
+  "httpx>=0.23.1",
   "python-dotenv>=1.1.1",
   "python-dateutil>=2.8.2",
-  "starlette>=0.48.0",
-  "uvicorn>=0.38.0",
+  "starlette>=0.27.0",
+  "uvicorn>=0.20.0",
   "tzdata>=2025.2",
 ]
 

--- a/uv.lock
+++ b/uv.lock
@@ -1,6 +1,6 @@
 version = 1
 revision = 1
-requires-python = ">=3.13"
+requires-python = ">=3.10"
 
 [[package]]
 name = "annotated-types"


### PR DESCRIPTION
lower minimum dependency versions for better compatibility

- mcp[cli]: 1.18.0 → 1.12.0 (matches requirements.txt)
- httpx: 0.28.1 → 0.23.1
- starlette: 0.48.0 → 0.27.0
- uvicorn: 0.38.0 → 0.20.0
- Remove argparse (Python stdlib)

Verified all dependencies support Python 3.10+ (project minimum).

### Project Python Version: ≥3.10

**Why Python 3.10 is required:**

1. Code uses PEP 604 union syntax (`A | B`) - requires Python 3.10+
2. `mcp[cli]` package requires Python 3.10+

chceking for #16 