### PR TITLE
docs: add Fronteir AI hosted deployment option

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,10 @@ A Model Context Protocol (MCP) server that provides weather information using th
   * **streamable-http** - Modern MCP Streamable HTTP protocol with stateful/stateless options
 * RESTful API endpoints via Starlette integration
 
+## Hosted deployment
+
+A hosted deployment is available on [Fronteir AI](https://fronteir.ai/mcp/isdaniel-mcp-weather-server).
+
 ## Installation
 
 ### Installing via Smithery


### PR DESCRIPTION
Love the project!

Adds a short note in the README that a hosted deployment is available on [Fronteir AI](https://fronteir.ai/mcp/isdaniel-mcp-weather-server).